### PR TITLE
Support batch override

### DIFF
--- a/aioinject/containers.py
+++ b/aioinject/containers.py
@@ -66,6 +66,21 @@ class Container:
         if previous is not None:
             self.providers[provider.type_] = previous
 
+    @contextlib.contextmanager
+    def override_batch(self, *providers: Provider[Any]) -> Iterator[None]:
+        previous: dict[type[Any], Provider[Any] | None] = {}
+        for provider in providers:
+            previous[provider.type_] = self.providers.get(provider.type_)
+            self.providers[provider.type_] = provider
+
+        yield
+
+        for provider in providers:
+            del self.providers[provider.type_]
+            prev = previous[provider.type_]
+            if prev is not None:
+                self.providers[provider.type_] = prev
+
     async def __aenter__(self) -> Self:
         return self
 

--- a/aioinject/containers.py
+++ b/aioinject/containers.py
@@ -53,21 +53,7 @@ class Container:
         )
 
     @contextlib.contextmanager
-    def override(
-        self,
-        provider: Provider[Any],
-    ) -> Iterator[None]:
-        previous = self.providers.get(provider.type_)
-        self.providers[provider.type_] = provider
-
-        yield
-
-        del self.providers[provider.type_]
-        if previous is not None:
-            self.providers[provider.type_] = previous
-
-    @contextlib.contextmanager
-    def override_batch(self, *providers: Provider[Any]) -> Iterator[None]:
+    def override(self, *providers: Provider[Any]) -> Iterator[None]:
         previous: dict[type[Any], Provider[Any] | None] = {}
         for provider in providers:
             previous[provider.type_] = self.providers.get(provider.type_)

--- a/tests/container/test_override.py
+++ b/tests/container/test_override.py
@@ -36,7 +36,7 @@ def test_override_batch() -> None:
     container.register(Object(0))
     container.register(Object("barfoo"))
 
-    with container.override_batch(
+    with container.override(
         Object(1),
         Object("foobar"),
     ), container.sync_context() as ctx:

--- a/tests/container/test_override.py
+++ b/tests/container/test_override.py
@@ -29,3 +29,20 @@ def test_override_multiple_times() -> None:
 
         with container.sync_context() as ctx:
             assert ctx.resolve(int) == 1
+
+
+def test_override_batch() -> None:
+    container = Container()
+    container.register(Object(0))
+    container.register(Object("barfoo"))
+
+    with container.override_batch(
+        Object(1),
+        Object("foobar"),
+    ), container.sync_context() as ctx:
+        assert ctx.resolve(int) == 1
+        assert ctx.resolve(str) == "foobar"
+
+    with container.sync_context() as ctx:
+        assert ctx.resolve(int) == 0
+        assert ctx.resolve(str) == "barfoo"


### PR DESCRIPTION
```py
def test_override_batch() -> None:
    container = Container()
    container.register(Object(0))
    container.register(Object("barfoo"))

    with container.override_batch(
        Object(1),
        Object("foobar"),
    ), container.sync_context() as ctx:
        assert ctx.resolve(int) == 1
        assert ctx.resolve(str) == "foobar"

    with container.sync_context() as ctx:
        assert ctx.resolve(int) == 0
        assert ctx.resolve(str) == "barfoo"
```