### PR TITLE
support batch register

### DIFF
--- a/aioinject/containers.py
+++ b/aioinject/containers.py
@@ -37,15 +37,18 @@ class Container:
 
     def register(
         self,
-        provider: Provider[Any],
+        *providers: Provider[Any],
     ) -> None:
-        if provider.type_ in self.providers:
-            msg = f"Provider for type {provider.type_} is already registered"
-            raise ValueError(msg)
+        for provider in providers:
+            if provider.type_ in self.providers:
+                msg = (
+                    f"Provider for type {provider.type_} is already registered"
+                )
+                raise ValueError(msg)
 
-        self.providers[provider.type_] = provider
-        if class_name := getattr(provider.type_, "__name__", None):
-            self.type_context[class_name] = provider.type_
+            self.providers[provider.type_] = provider
+            if class_name := getattr(provider.type_, "__name__", None):
+                self.type_context[class_name] = provider.type_
 
     def get_provider(self, type_: type[T]) -> Provider[T]:
         try:

--- a/benchmark/container.py
+++ b/benchmark/container.py
@@ -25,7 +25,5 @@ providers: Sequence[Provider[Any]] = [
 
 def create_container() -> aioinject.Container:
     container = aioinject.Container()
-    for provider in providers:
-        container.register(provider=provider)
-
+    container.register(*providers)
     return container

--- a/docs/code/contextmanagers/03_implicity.py
+++ b/docs/code/contextmanagers/03_implicity.py
@@ -1,5 +1,6 @@
 from types import TracebackType
-from typing import Self
+
+from typing_extensions import Self
 
 import aioinject
 from aioinject import Scoped

--- a/docs/code/example.py
+++ b/docs/code/example.py
@@ -24,8 +24,9 @@ class UserService:
 
 
 container = aioinject.Container()
-container.register(aioinject.Singleton(Database))
-container.register(aioinject.Singleton(UserService))
+container.register(
+    aioinject.Singleton(Database), aioinject.Singleton(UserService),
+)
 
 with container.sync_context() as ctx:
     service = ctx.resolve(UserService)

--- a/docs/code/example.py
+++ b/docs/code/example.py
@@ -25,7 +25,8 @@ class UserService:
 
 container = aioinject.Container()
 container.register(
-    aioinject.Singleton(Database), aioinject.Singleton(UserService),
+    aioinject.Singleton(Database),
+    aioinject.Singleton(UserService),
 )
 
 with container.sync_context() as ctx:

--- a/tests/container/test_container.py
+++ b/tests/container/test_container.py
@@ -43,6 +43,14 @@ def test_can_register_single(container: Container) -> None:
     assert container.providers == expected
 
 
+def test_can_register_batch(container: Container) -> None:
+    provider1 = providers.Scoped(_ServiceA)
+    provider2 = providers.Scoped(_ServiceB)
+    container.register(provider1, provider2)
+    excepted = {_ServiceA: provider1, _ServiceB: provider2}
+    assert container.providers == excepted
+
+
 def test_cant_register_multiple_providers_for_same_type(
     container: Container,
 ) -> None:

--- a/tests/extensions/mypy_test.py
+++ b/tests/extensions/mypy_test.py
@@ -6,7 +6,6 @@ from aioinject.extensions import OnResolveExtension, SyncOnResolveExtension
 
 
 class _TestExtension(SyncOnResolveExtension, OnResolveExtension):
-
     async def on_resolve(
         self,
         context: InjectionContext,


### PR DESCRIPTION
i.e
Before
```py
	cont.register(aioinject.Singleton(get_settings))
	cont.register(aioinject.Singleton(get_redis))
	cont.register(aioinject.Singleton(get_pub_sub))
	cont.register(aioinject.Singleton(EventAbleDeviceRepo))
	cont.register(aioinject.Singleton(EventAbleService))
	cont.register(aioinject.Singleton(EventsPuller))
```
After
```py
	cont.register(
		aioinject.Singleton(get_settings),
		aioinject.Singleton(get_redis),
		aioinject.Singleton(get_pub_sub),
		aioinject.Singleton(EventAbleDeviceRepo),
		aioinject.Singleton(EventAbleService),
		aioinject.Singleton(EventsPuller),
	)
```