### PR TITLE
fix: nested generics (#23) 

### DIFF
--- a/aioinject/_features/generics.py
+++ b/aioinject/_features/generics.py
@@ -94,7 +94,7 @@ def _py310_compat_resolve_generics_factory(
     # we need to exec a string to avoid syntax errors
     # we will create a function that will return the resolved generic
 
-    if False:
+    if is_py_gt3_311:
         fn_impl = textwrap.dedent("""
         def _resolve_generic(
             generic_alias: type,

--- a/aioinject/_features/generics.py
+++ b/aioinject/_features/generics.py
@@ -93,6 +93,8 @@ def _py310_compat_resolve_generics_factory(
 ) -> Callable[[type, tuple[type, ...]], type]:
     # we need to exec a string to avoid syntax errors
     # we will create a function that will return the resolved generic
+    # for python 3.11 and later we can use `generic_alias[*args]` which will consider
+    # see `test_partially_resolved_generic` for more details
 
     if is_py_gt3_311:
         fn_impl = textwrap.dedent("""

--- a/aioinject/_features/generics.py
+++ b/aioinject/_features/generics.py
@@ -85,19 +85,19 @@ def get_generic_parameter_map(
     return result
 
 
-def is_py_gt3_311() -> bool:
+def is_py_gt3_311() -> bool:  # pragma: no cover
     return sys.version_info >= (3, 11)
 
 
 def _py310_compat_resolve_generics_factory() -> (
     Callable[[type, tuple[type, ...]], type]
-):
+):  # pragma: no cover
     # we need to exec a string to avoid syntax errors
     # we will create a function that will return the resolved generic
     # for python 3.11 and later we can use `generic_alias[*args]` which will consider
     # see `test_partially_resolved_generic` for more details
 
-    if is_py_gt3_311:
+    if is_py_gt3_311():
         fn_impl = textwrap.dedent("""
         def _resolve_generic(
             generic_alias: type,
@@ -113,7 +113,7 @@ def _py310_compat_resolve_generics_factory() -> (
         ) -> type:
             return generic_alias.__getitem__(*args)
         """)
-    exec_globals = {}
+    exec_globals: dict[str, Any] = {}
     exec(fn_impl, exec_globals)  # noqa: S102
     return exec_globals["_resolve_generic"]
 

--- a/aioinject/_features/generics.py
+++ b/aioinject/_features/generics.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import functools
-import sys
-import textwrap
 import types
 import typing as t
-from collections.abc import Callable
 from types import GenericAlias
 from typing import TYPE_CHECKING, Any, TypeGuard
 
@@ -79,43 +76,5 @@ def get_generic_parameter_map(
                 args_map[arg.__name__] for arg in generic_arguments
             )
             #  We can use `[]` when we drop support for 3.10
-            result[dependency.name] = _py310_compat_resolve_generics(
-                inner_type, resolved_args
-            )
+            result[dependency.name] = inner_type[resolved_args]
     return result
-
-
-def is_py_gt3_311() -> bool:  # pragma: no cover
-    return sys.version_info >= (3, 11)
-
-
-def _py310_compat_resolve_generics_factory() -> (
-    Callable[[type, tuple[type, ...]], type]
-):  # pragma: no cover
-    # we need to exec a string to avoid syntax errors
-    # we will create a function that will return the resolved generic
-    # for python 3.11 and later we can use `generic_alias[*args]` which will consider
-    # see `test_partially_resolved_generic` for more details
-
-    if is_py_gt3_311():
-        fn_impl = textwrap.dedent("""
-        def _resolve_generic(
-            generic_alias: type,
-            args: tuple[type, ...],
-        ) -> type:
-            return generic_alias[*args]
-        """)
-    else:
-        fn_impl = textwrap.dedent("""
-        def _resolve_generic(
-            generic_alias: type,
-            args: tuple[type, ...],
-        ) -> type:
-            return generic_alias.__getitem__(*args)
-        """)
-    exec_globals: dict[str, Any] = {}
-    exec(fn_impl, exec_globals)  # noqa: S102
-    return exec_globals["_resolve_generic"]
-
-
-_py310_compat_resolve_generics = _py310_compat_resolve_generics_factory()

--- a/aioinject/_features/generics.py
+++ b/aioinject/_features/generics.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 import functools
 import sys
-from textwrap import wrap
 import textwrap
 import types
 import typing as t
+from collections.abc import Callable
 from types import GenericAlias
 from typing import TYPE_CHECKING, Any, TypeGuard
 
@@ -89,8 +88,10 @@ def get_generic_parameter_map(
 def is_py_gt3_311() -> bool:
     return sys.version_info >= (3, 11)
 
-def _py310_compat_resolve_generics_factory(
-) -> Callable[[type, tuple[type, ...]], type]:
+
+def _py310_compat_resolve_generics_factory() -> (
+    Callable[[type, tuple[type, ...]], type]
+):
     # we need to exec a string to avoid syntax errors
     # we will create a function that will return the resolved generic
     # for python 3.11 and later we can use `generic_alias[*args]` which will consider
@@ -115,5 +116,6 @@ def _py310_compat_resolve_generics_factory(
     exec_globals = {}
     exec(fn_impl, exec_globals)  # noqa: S102
     return exec_globals["_resolve_generic"]
+
 
 _py310_compat_resolve_generics = _py310_compat_resolve_generics_factory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "mkdocs-material>=9.5.44",
     "mypy>=1.13.0",
     "pydantic-settings>=2.6.1",
+    "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
     "ruff>=0.7.4",
     "strawberry-graphql>=0.248.1",

--- a/tests/features/test_generics.py
+++ b/tests/features/test_generics.py
@@ -7,6 +7,7 @@ import pytest
 
 from aioinject import Container, Object, Scoped
 from aioinject.providers import Dependency, Transient
+from tests.utils_ import py_gte_311
 
 
 T = TypeVar("T")
@@ -94,7 +95,10 @@ async def test_resolve_generics(
         assert isinstance(instance, instanceof)
 
 
-@pytest.mark.py_gte_311
+@py_gte_311("""
+            prior to 3.11 using generic_alias[] considered a syntax error
+            its very hard to overcome this due to `test_partially_resolved_generic`
+            """)
 async def test_nested_generics() -> None:
     container = Container()
     container.register(
@@ -116,7 +120,7 @@ async def test_nested_generics() -> None:
 async def test_nested_unresolved_generic() -> None:
     @dataclass
     class NestedUnresolvedGeneric:
-        service: SimpleGeneric
+        service: SimpleGeneric  # type: ignore[type-arg]
 
     container = Container()
     obj = SimpleGeneric(MEANING_OF_LIFE_INT)

--- a/tests/features/test_generics.py
+++ b/tests/features/test_generics.py
@@ -7,7 +7,6 @@ import pytest
 
 from aioinject import Container, Object, Scoped
 from aioinject.providers import Dependency, Transient
-from tests.utils_ import py_gte_311
 
 
 T = TypeVar("T")
@@ -95,10 +94,6 @@ async def test_resolve_generics(
         assert isinstance(instance, instanceof)
 
 
-@py_gte_311("""
-            prior to 3.11 using generic_alias[] considered a syntax error
-            its very hard to overcome this due to `test_partially_resolved_generic`
-            """)
 async def test_nested_generics() -> None:
     container = Container()
     container.register(

--- a/tests/utils_.py
+++ b/tests/utils_.py
@@ -1,6 +1,6 @@
 import functools
-from collections.abc import Callable
 import sys
+from collections.abc import Callable
 from typing import ParamSpec, TypeVar
 
 import pytest

--- a/tests/utils_.py
+++ b/tests/utils_.py
@@ -1,9 +1,6 @@
 import functools
-import sys
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
-
-import pytest
 
 
 T = TypeVar("T")
@@ -16,10 +13,3 @@ def dummy_decorator(func: Callable[P, T]) -> Callable[P, T]:
         return func(*args, **kwargs)
 
     return decorator
-
-
-def py_gte_311(reason: str) -> pytest.MarkDecorator:
-    return pytest.mark.skipif(
-        sys.version_info < (3, 11),
-        reason=reason,
-    )

--- a/tests/utils_.py
+++ b/tests/utils_.py
@@ -18,7 +18,8 @@ def dummy_decorator(func: Callable[P, T]) -> Callable[P, T]:
     return decorator
 
 
-py_gte_311 = pytest.mark.skipif(
-    sys.version_info < (3, 11),
-    reason="This test requires Python 3.11 or later",
-)
+def py_gte_311(reason: str) -> pytest.MarkDecorator:
+    return pytest.mark.skipif(
+        sys.version_info < (3, 11),
+        reason=reason,
+    )

--- a/tests/utils_.py
+++ b/tests/utils_.py
@@ -1,6 +1,9 @@
 import functools
 from collections.abc import Callable
+import sys
 from typing import ParamSpec, TypeVar
+
+import pytest
 
 
 T = TypeVar("T")
@@ -13,3 +16,9 @@ def dummy_decorator(func: Callable[P, T]) -> Callable[P, T]:
         return func(*args, **kwargs)
 
     return decorator
+
+
+py_gte_311 = pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="This test requires Python 3.11 or later",
+)

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "aioinject"
-version = "0.35.3"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "typing-extensions" },
@@ -343,7 +343,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -751,7 +751,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ dev = [
     { name = "mypy" },
     { name = "pydantic-settings" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "strawberry-graphql" },
     { name = "trio" },
@@ -160,6 +161,7 @@ dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pydantic-settings", specifier = ">=2.6.1" },
     { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.7.4" },
     { name = "strawberry-graphql", specifier = ">=0.248.1" },
     { name = "trio", specifier = ">=0.27.0" },
@@ -1241,6 +1243,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341 },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949 },
 ]
 
 [[package]]


### PR DESCRIPTION
- fix #23
- refactor generic tests

Note that this only supports py311 and above

I also added `pytest-cov` to deps which allows you to run coverage within vs code 
![image](https://github.com/user-attachments/assets/0c42bd04-73c8-405f-92cf-db43ddf5c872)
if you care, I'll remove this.